### PR TITLE
Relax py-spy constraint to allow py-spy==0.4.0 to be installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.8"
 distributed = ">=2.30.0"
-py-spy = "^0.3.9"
+py-spy = ">=0.3.9"
 
 [tool.poetry.group.docker.dependencies]
 bokeh = "^2.3.1"


### PR DESCRIPTION
Note: It looks like there is a problem with installing dev dependencies on M1, so I couldn't run the test.